### PR TITLE
Avoid infinite loops on test-case file

### DIFF
--- a/src/main/cobol/ZUTZCPC.CBL
+++ b/src/main/cobol/ZUTZCPC.CBL
@@ -43,6 +43,7 @@
        FD  ORIGINAL-SOURCE
            DATA RECORD IS ORIGINAL-LINE.
        01  ORIGINAL-LINE.
+         03  ORIGINAL-LINE-FOR-REDEFINE. 
            05  FILLER                    PIC X(07).
            05  SECTION-HEADER            PIC X(10).
                88  DATA-DIVISION-HEADER      VALUE 'DATA DIVIS'.
@@ -58,7 +59,7 @@
                10  PARA-HEADER-AREA      PIC X(04).
                10  FILLER                PIC X(06).    
            05  FILLER                    PIC X(63).
-       01  FILLER REDEFINES ORIGINAL-LINE.
+         03  FILLER REDEFINES ORIGINAL-LINE-FOR-REDEFINE. 
            05  FILLER                    PIC X(07).
            05  PARAGRAPH-NAME            PIC X(31).
            05  FILLER                    PIC X(42).    
@@ -270,7 +271,7 @@
        01  GENERATED-SOURCE-STATEMENTS.
            05  GENERATED-SOURCE-STATEMENT 
                OCCURS 100 
-               INDEXED BY STATEMENT-IX   PIC X(160).
+               INDEXED BY STATEMENT-IX   PIC X(160) VALUE SPACES.
                    
       *****************************************************************
       * Accumulate source statements that will be inserted into the 
@@ -279,7 +280,7 @@
        01  INITIALIZATION-STATEMENTS.
            05  INITIALIZATION-STATEMENT 
                OCCURS 50 
-               INDEXED BY INITIALIZATION-IX PIC X(80).
+               INDEXED BY INITIALIZATION-IX PIC X(80) VALUE SPACES.
 
       *****************************************************************
       * Accumulate source statements that will be inserted into the 
@@ -288,7 +289,7 @@
        01  BEFORE-EACH-STATEMENTS.
            05  BEFORE-EACH-STATEMENT
                OCCURS 50
-               INDEXED BY BEFORE-EACH-IX PIC X(80).        
+               INDEXED BY BEFORE-EACH-IX PIC X(80) VALUE SPACES.        
 
       *****************************************************************
       * Accumulate source statements that will be inserted into the 
@@ -297,7 +298,7 @@
        01  AFTER-EACH-STATEMENTS.
            05  AFTER-EACH-STATEMENT
                OCCURS 50
-               INDEXED BY AFTER-EACH-IX PIC X(80).        
+               INDEXED BY AFTER-EACH-IX PIC X(80) VALUE SPACES.        
 
       *****************************************************************
       * Build source statements for the UT-MOCK-INFO table to be
@@ -306,7 +307,7 @@
        01  MOCK-INFO-LINES.
            05  MOCK-INFO-LINE
                OCCURS 50
-               INDEXED BY MOCK-INFO-IX PIC X(80).
+               INDEXED BY MOCK-INFO-IX PIC X(80) VALUE SPACES.
 
       *****************************************************************
       * Build source statements for the UT-LOOKUP-MOCK paragraph to be
@@ -315,7 +316,7 @@
        01  LOOKUP-MOCK-REPLACEMENT-STMTS.
            05  LOOKUP-MOCK-REPLACEMENT-STMT
                OCCURS 50
-               INDEXED BY LOOKUP-MOCK-IX PIC X(80).
+               INDEXED BY LOOKUP-MOCK-IX PIC X(80) VALUE SPACES.
 
       *****************************************************************
       * This is a work area used when tokenizing a line of input from
@@ -341,15 +342,15 @@
            05  KEYWORD-MATCHED-INDICATOR PIC X(01) VALUE 'N'.
                88  KEYWORD-MATCHED              VALUE 'Y'.
                88  KEYWORD-NOT-MATCHED          VALUE 'N'.
-           05  WS-CHARS               PIC 9(02) VALUE ZERO.  
-           05  WS-NEXT                PIC 9(02) VALUE ZERO.
+           05  WS-CHARS               PIC 9(02) VALUE ZERO COMP.  
+           05  WS-NEXT                PIC 9(02) VALUE ZERO COMP.
            05  WS-STRING-DELIMITER    PIC X(01) VALUE SPACE.  
            05  KEYWORD-TO-MATCH       PIC X(20) VALUE SPACES.
            05  KEYWORD-MATCH-LENGTH   PIC 9(02) VALUE ZERO.
-           05  KEYWORD-OFFSET         PIC 9(02) VALUE 0.
+           05  KEYWORD-OFFSET         PIC 9(02) VALUE 0 COMP.
            05  KEYWORD-SEARCH-LIMIT   PIC 9(02) VALUE 0.
-           05  KEYWORD-END            PIC 9(02) VALUE 72.
-           05  KEYWORD-START          PIC 9(02) VALUE 12.
+           05  KEYWORD-END            PIC 9(02) VALUE 72 COMP.
+           05  KEYWORD-START          PIC 9(02) VALUE 12 COMP.
            05  MAX-KEYWORDS           PIC 9(02) VALUE 8.
            05  KEYWORD-VALUES.
                10  FILLER PIC X(20) VALUE 'EXPECT'.
@@ -1140,6 +1141,11 @@
            05  MSG-EXPECT-SYNTAX-3.
                10  FILLER PIC X(80) VALUE 
                '    EXPECT [actual] TO BE [expected]'.
+      
+           05  MSG-TEST-CASES-MISSING-END.                   
+               10  FILLER PIC X(06) VALUE '017-E '.          
+               10  FILLER                   PIC X(33) VALUE  
+                   'TEST CASE NEEDS A . AS LAST TOKEN'.      
 
        LINKAGE SECTION.
 
@@ -1542,7 +1548,7 @@
            SET FILENAME-NOT-MATCHED TO TRUE
            PERFORM 6400-GET-FILE-INFO-FOR-MOCK
            IF FILENAME-MATCHED
-               PERFORM 3300-GEN-MOCK-REPLACEMENT-STMTS
+               PERFORM 3300-GEN-MOCK-REPLACE-STMTS
            ELSE
                SET COPY-SOURCE TO TRUE
                MOVE MOCK-FILENAME(MOCK-IX) 
@@ -1555,7 +1561,7 @@
            END-IF        
            .
 
-       3300-GEN-MOCK-REPLACEMENT-STMTS.
+       3300-GEN-MOCK-REPLACE-STMTS.
       *****************************************************************
       * Generate code in TEST-SOURCE to substitute mock behavior for
       * the real I/O functionality.
@@ -1770,8 +1776,8 @@
       * See if we have read a paragraph header line from 
       * ORIGINAL-SOURCE.
       *****************************************************************
-          SET MOCKABLE-NOT-FOUND TO TRUE
-          IF PARA-HEADER-AREA IS EQUAL TO SPACES
+           SET MOCKABLE-NOT-FOUND TO TRUE
+           IF PARA-HEADER-AREA IS EQUAL TO SPACES
                CONTINUE
            ELSE
                PERFORM 7640-SET-SAVE-ORIG-LINES
@@ -3238,7 +3244,7 @@
       *             [tokens]
       *             END-CALL
       *         [any Cobol statements]
-      *     END-CALL
+      *     END-MOCK
       *
       * By the time this routine is performed, the keyword CALL has
       * already been processed.
@@ -3621,10 +3627,11 @@
                           OR MOCK-REPLACEMENT-STMT
                              (MOCK-IX, MOCK-REPLACEMENT-STMTS-IX) 
                              IS EQUAL TO SPACES
+                   SET STATEMENT-IX TO MOCK-REPLACEMENT-STMTS-IX 
                    MOVE MOCK-REPLACEMENT-STMT
                              (MOCK-IX, MOCK-REPLACEMENT-STMTS-IX)
                        TO GENERATED-SOURCE-STATEMENT
-                             (MOCK-REPLACEMENT-STMTS-IX)          
+                             (STATEMENT-IX)       
                END-PERFORM                 
                PERFORM 9440-WRITE-GENERATED-STMTS    
            END-IF
@@ -3780,6 +3787,7 @@
                ELSE
                    IF SCANNING-TEST-CASES
                        PERFORM 9350-READ-TEST-CASES
+                       PERFORM 7315-IS-END-OF-TEST-CASES 
                        MOVE TEST-CASE-LINE TO LINE-TO-PARSE   
                    ELSE
                        PERFORM 9460-COPY-ORIGINAL-LINE
@@ -3789,6 +3797,15 @@
                    MOVE KEYWORD-START TO KEYWORD-OFFSET
                END-IF            
            END-PERFORM
+           .                                                           
+       7315-IS-END-OF-TEST-CASES.                                      
+      *****************************************************************
+      * Dev has forgotten a . as end of test case file.                
+      *****************************************************************
+           IF END-OF-TEST-CASES                                        
+             MOVE PARAGRAPH-END-MARKER TO TEST-CASE-LINE               
+             DISPLAY MSG-TEST-CASES-MISSING-END                        
+           END-IF                                                      
            .
 
        7320-FIND-NEXT-SPACE.
@@ -4158,7 +4175,7 @@
            .
 
        9290-CLOSE-ORIGINAL-SOURCE.
-           CLOSE ORIGINAL-SOURCE.
+           CLOSE ORIGINAL-SOURCE
            .
 
       *****************************************************************
@@ -4209,7 +4226,7 @@
            .
 
        9390-CLOSE-TEST-CASES.
-           CLOSE TEST-CASES.
+           CLOSE TEST-CASES
            .
 
       *****************************************************************

--- a/src/main/cobol/ZUTZCPC.CBL
+++ b/src/main/cobol/ZUTZCPC.CBL
@@ -1140,6 +1140,11 @@
            05  MSG-EXPECT-SYNTAX-3.
                10  FILLER PIC X(80) VALUE 
                '    EXPECT [actual] TO BE [expected]'.
+      
+           05  MSG-TEST-CASES-MISSING-END.                  
+               10  FILLER PIC X(06) VALUE '017-E '.         
+               10  FILLER                   PIC X(33) VALUE 
+               'TEST CASE NEEDS A . AS LAST TOKEN'.     
 
        LINKAGE SECTION.
 
@@ -3780,6 +3785,7 @@
                ELSE
                    IF SCANNING-TEST-CASES
                        PERFORM 9350-READ-TEST-CASES
+                       PERFORM 7315-IS-END-OF-TEST-CASES
                        MOVE TEST-CASE-LINE TO LINE-TO-PARSE   
                    ELSE
                        PERFORM 9460-COPY-ORIGINAL-LINE
@@ -3790,6 +3796,15 @@
                END-IF            
            END-PERFORM
            .
+       7315-IS-END-OF-TEST-CASES.                                      
+      *****************************************************************
+      * Dev has forgotten a . as end of test case file.                
+      *****************************************************************
+           IF END-OF-TEST-CASES                                        
+             MOVE PARAGRAPH-END-MARKER TO TEST-CASE-LINE               
+             DISPLAY MSG-TEST-CASES-MISSING-END                        
+           END-IF                                                      
+           .                                                           
 
        7320-FIND-NEXT-SPACE.
            IF LINE-TO-PARSE(KEYWORD-OFFSET:1) IS EQUAL TO SPACE

--- a/upload/ZUTZCPC
+++ b/upload/ZUTZCPC
@@ -1121,6 +1121,11 @@
            05  MSG-EXPECT-SYNTAX-3.                                             
                10  FILLER PIC X(80) VALUE                                       
                '    EXPECT [actual] TO BE [expected]'.                          
+               
+           05  MSG-TEST-CASES-MISSING-END.                  
+               10  FILLER PIC X(06) VALUE '017-E '.         
+               10  FILLER                   PIC X(33) VALUE 
+               'TEST CASE NEEDS A . AS LAST TOKEN'.     
                                                                                 
        LINKAGE SECTION.                                                         
                                                                                 

--- a/upload/ZUTZCPC
+++ b/upload/ZUTZCPC
@@ -43,6 +43,7 @@
        FD  ORIGINAL-SOURCE                                                      
            DATA RECORD IS ORIGINAL-LINE.                                        
        01  ORIGINAL-LINE.                                                       
+         03 ORIGINAL-LINE-FOR-REDEFINE. 
            05  FILLER                    PIC X(07).                             
            05  SECTION-HEADER            PIC X(10).                             
                88  DATA-DIVISION-HEADER      VALUE 'DATA DIVIS'.                
@@ -62,7 +63,7 @@
                10  PARA-HEADER-AREA      PIC X(04).                             
                10  FILLER                PIC X(06).                             
            05  FILLER                    PIC X(63).                             
-       01  FILLER REDEFINES ORIGINAL-LINE.                                      
+         03  FILLER REDEFINES ORIGINAL-LINE.                                      
            05  FILLER                    PIC X(07).                             
            05  PARAGRAPH-NAME            PIC X(31).                             
            05  FILLER                    PIC X(42).                             
@@ -332,15 +333,15 @@
            05  KEYWORD-MATCHED-INDICATOR PIC X(01) VALUE 'N'.                   
                88  KEYWORD-MATCHED              VALUE 'Y'.                      
                88  KEYWORD-NOT-MATCHED          VALUE 'N'.                      
-           05  WS-CHARS               PIC 9(02) VALUE ZERO.                     
-           05  WS-NEXT                PIC 9(02) VALUE ZERO.                     
+           05  WS-CHARS               PIC 9(02) VALUE ZERO COMP.                     
+           05  WS-NEXT                PIC 9(02) VALUE ZERO COMP.                     
            05  WS-STRING-DELIMITER    PIC X(01) VALUE SPACE.                    
            05  KEYWORD-TO-MATCH       PIC X(20) VALUE SPACES.                   
            05  KEYWORD-MATCH-LENGTH   PIC 9(02) VALUE ZERO.                     
-           05  KEYWORD-OFFSET         PIC 9(02) VALUE 0.                        
+           05  KEYWORD-OFFSET         PIC 9(02) VALUE 0 COMP.                        
            05  KEYWORD-SEARCH-LIMIT   PIC 9(02) VALUE 0.                        
-           05  KEYWORD-END            PIC 9(02) VALUE 72.                       
-           05  KEYWORD-START          PIC 9(02) VALUE 12.                       
+           05  KEYWORD-END            PIC 9(02) VALUE 72 COMP.                       
+           05  KEYWORD-START          PIC 9(02) VALUE 12 COMP.                       
            05  MAX-KEYWORDS           PIC 9(02) VALUE 8.                        
            05  KEYWORD-VALUES.                                                  
                10  FILLER PIC X(20) VALUE 'EXPECT'.                             
@@ -1715,8 +1716,8 @@
       * See if we have read a paragraph header line from                        
       * ORIGINAL-SOURCE.                                                        
       *****************************************************************         
-          SET MOCKABLE-NOT-FOUND TO TRUE                                        
-          IF PARA-HEADER-AREA IS EQUAL TO SPACES                                
+           SET MOCKABLE-NOT-FOUND TO TRUE                                        
+           IF PARA-HEADER-AREA IS EQUAL TO SPACES                                
                CONTINUE                                                         
            ELSE                                                                 
                PERFORM 7640-SET-SAVE-ORIG-LINES                                 
@@ -1800,6 +1801,7 @@
       *****************************************************************         
       * EXEC SQL was found. Future implementation.                              
       *****************************************************************         
+           CONTINUE
            .                                                                    
                                                                                 
        2900-COPY-OR-COMMENT-LINES.                                              
@@ -3893,7 +3895,7 @@
            .                                                                    
                                                                                 
        9290-CLOSE-ORIGINAL-SOURCE.                                              
-           CLOSE ORIGINAL-SOURCE.                                               
+           CLOSE ORIGINAL-SOURCE                                               
            .                                                                    
                                                                                 
       *****************************************************************         
@@ -3944,7 +3946,7 @@
            .                                                                    
                                                                                 
        9390-CLOSE-TEST-CASES.                                                   
-           CLOSE TEST-CASES.                                                    
+           CLOSE TEST-CASES                                                    
            .                                                                    
                                                                                 
       *****************************************************************         

--- a/upload/ZUTZCPC
+++ b/upload/ZUTZCPC
@@ -63,7 +63,7 @@
                10  PARA-HEADER-AREA      PIC X(04).                             
                10  FILLER                PIC X(06).                             
            05  FILLER                    PIC X(63).                             
-         03  FILLER REDEFINES ORIGINAL-LINE.                                      
+         03  FILLER REDEFINES ORIGINAL-LINE-FOR-REDEFINE.                                      
            05  FILLER                    PIC X(07).                             
            05  PARAGRAPH-NAME            PIC X(31).                             
            05  FILLER                    PIC X(42).                             

--- a/upload/ZUTZCPC
+++ b/upload/ZUTZCPC
@@ -3519,7 +3519,8 @@
                    SET NON-SPACE-FOUND TO TRUE                                  
                ELSE                                                             
                    IF SCANNING-TEST-CASES                                       
-                       PERFORM 9350-READ-TEST-CASES                             
+                       PERFORM 9350-READ-TEST-CASES
+                       PERFORM 7315-IS-END-OF-TEST-CASES
                        MOVE TEST-CASE-LINE TO LINE-TO-PARSE                     
                    ELSE                                                         
                        PERFORM 9460-COPY-ORIGINAL-LINE                          
@@ -3530,6 +3531,15 @@
                END-IF                                                           
            END-PERFORM                                                          
            .                                                                    
+       7315-IS-END-OF-TEST-CASES.                                      
+      *****************************************************************
+      * Dev has forgotten a . as end of test case file.                
+      *****************************************************************
+       IF END-OF-TEST-CASES                                        
+         MOVE PARAGRAPH-END-MARKER TO TEST-CASE-LINE               
+         DISPLAY MSG-TEST-CASES-MISSING-END                        
+       END-IF                                                      
+       .                                                           
                                                                                 
        7320-FIND-NEXT-SPACE.                                                    
            IF LINE-TO-PARSE(KEYWORD-OFFSET:1) IS EQUAL TO SPACE                 


### PR DESCRIPTION
If a dev forgets a "." in the end of the test-case file, this causes an infinite loop in the 7310-FIND-NEXT-NON-SPACE paragraph.
This is avoided by identifying that eof is reached, and moving a PARAGRAPH-END-MARKER in as the content from the test-case file.